### PR TITLE
[Fix] Working with Webpack 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,17 +44,3 @@ See [example](/example) of connection.
 ## Usage in React project
 
 If you want to send source maps of your React project, you need to use [react-app-rewired](https://github.com/timarney/react-app-rewired) or do `yarn eject`. Then you can override Webpack config of your project and use this plugin.
-
-## Troubleshooting
-
-### `The "path" argument must be of type string or an instance of Buffer or URL. Received undefined`
-
-In Webpack 4 you need to add this property to your config:
-```js
-module.exports = {
-  // Webpack configuration
-  output: {
-    futureEmitAssets: false
-  }
-}
-```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hawk.so/webpack-plugin",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Webpack plugin for sending source-maps to the Hawk",
   "main": "src/index.js",
   "repository": "https://github.com/codex-team/hawk.webpack.plugin.git",

--- a/src/index.js
+++ b/src/index.js
@@ -119,12 +119,13 @@ class HawkWebpackPlugin {
    */
   findSourceMaps(compilation){
     const maps = [];
+    const outputPath = compilation.outputOptions.path;
 
     Object.keys(compilation.assets).forEach(name => {
       if (name.split('.').pop() === 'map'){
         maps.push({
           name,
-          path: compilation.assets[name].existsAt
+          path: path.join(outputPath, name),
         })
       }
     })


### PR DESCRIPTION
Now plugin gets a path to assets by joining an output path and an asset filename.
Closes #23 