### PR TITLE
Fix detection map files when asset name has a query string

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hawk.so/webpack-plugin",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Webpack plugin for sending source-maps to the Hawk",
   "main": "src/index.js",
   "repository": "https://github.com/codex-team/hawk.webpack.plugin.git",

--- a/src/index.js
+++ b/src/index.js
@@ -204,7 +204,10 @@ class HawkWebpackPlugin {
     const outputPath = compilation.outputOptions.path;
 
     Object.keys(compilation.assets).forEach(name => {
-      if (name.split('.').pop() === 'map') {
+      const filename = name.split('?')[0];
+      const extension = filename.split('.').pop();
+
+      if (extension === 'map') {
         maps.push({
           name,
           path: path.join(outputPath, name),


### PR DESCRIPTION
Hello.
Currently the plugin incorrectly finds map files if the asset has a name with query string.
For example my webpack.config.js:
```js
module.exports = {
    // ...
    output: {
        // ...
        filename: `[name].bundle.js`,
        chunkFilename: '[name].bundle.js?ncrnd=[contenthash:8]',
        // ...
    },
    // ...
};
```

For entry files (`filename`) detection occurs correctly, since it does not contain a query string, but for asynchronous chunks (`chunkFilename`) it is detected incorrectly: in the example below in the screenshot, instead of an extension, the result is an extension + query string.

I suggest before splitting a string into dots, firstly split it at "?" and take its first/left part, that is, the file name itself, and after that split it into dots, as it is now.

![image](https://github.com/codex-team/hawk.webpack.plugin/assets/10882576/221b2b77-d335-438c-932e-0b752e54e014)
