### PR TITLE
Use filename of map file without query string

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hawk.so/webpack-plugin",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Webpack plugin for sending source-maps to the Hawk",
   "main": "src/index.js",
   "repository": "https://github.com/codex-team/hawk.webpack.plugin.git",

--- a/src/index.js
+++ b/src/index.js
@@ -210,7 +210,7 @@ class HawkWebpackPlugin {
       if (extension === 'map') {
         maps.push({
           name,
-          path: path.join(outputPath, name),
+          path: path.join(outputPath, filename),
         });
       }
     });


### PR DESCRIPTION
Guys, I've fucked up in #43.
I'm sorry. There is fix.

Detection `*.map` was fixed, but the path to the file itself remained with the query string.

![2024-05-29_23-56](https://github.com/codex-team/hawk.webpack.plugin/assets/10882576/90ebb49c-f981-4bda-860e-64009860c489)

cc @GeekaN2 @n0str @neSpecc 