### PR TITLE
Imp (docs): improve docs and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,12 @@ yarn add @hawk.so/webpack-plugin --save-dev
 
 Next you need to connect plugin to the Webpack config.
 
-Pass your Integration Token as plugin option. It is useful to store it in .env file. 
+Pass your Integration Token as plugin option. It is useful to store it in .env file.
+
+> [!IMPORTANT]
+> Note, that devtool should be set to "source-map" for full source map content
+> That can cause your source code to be leaked if you set HawkWebpackPlugin.removeSourceMaps to false
+> But by default all of the source map files would be deleted after sending by the plugin 
 
 ```js
 const HawkWebpackPlugin = require('@hawk.so/webpack-plugin');
@@ -23,7 +28,7 @@ module.exports = {
       integrationToken: '' // Your project's Integration Token
     })
   ],
-  devtool: 'hidden-source-map',
+  devtool: 'source-map',
 }
 ```
 

--- a/example/README.md
+++ b/example/README.md
@@ -55,7 +55,7 @@ module.exports = {
     minimize: true,
     minimizer: [new TerserPlugin()],
   },
-  devtool: "hidden-source-map",
+  devtool: "source-map",
 };
 
 ```

--- a/example/webpack.config.cjs
+++ b/example/webpack.config.cjs
@@ -43,5 +43,5 @@ module.exports = {
     compress: true,
     port: 9000,
   },
-  devtool: "hidden-source-map",
+  devtool: "source-map",
 };


### PR DESCRIPTION
## Problem
if `webpack.config.js` devtool would be set to 'hidden-source-maps', then we will have not enough information about function name parsing from backtrace and it might look like this 
![image](https://github.com/user-attachments/assets/418b29ef-ae0b-46c1-92a1-0e45be7a27cd)

## Solution
This is a Client side custom option, so we could update only readme and example with this information