### PR TITLE
Add tracking marker to JavaScript chunks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,9 @@ class HawkWebpackPlugin {
    * @param {Compiler} compiler
    */
   apply(compiler) {
-    // Add tracking marker to JS chunks before emitting
+    /**
+     * Add tracking marker to JS chunks before emitting
+     */
     compiler.hooks.emit.tap('HawkWebpackPlugin', (compilation) => {
       this.addTrackingMarker(compilation);
     });
@@ -218,10 +220,15 @@ class HawkWebpackPlugin {
         const asset = compilation.assets[assetName];
         const source = asset.source();
 
-        // Check if marker already exists to avoid duplicates
-        if (!source.includes('HAWK:tracked')) {
-          // Prepend marker to the beginning of the file
+        /**
+         * Check if marker already exists to avoid duplicates
+         */
+        if (!source.includes(trackingMarker)) {
+          /**
+           * Prepend marker to the beginning of the file
+           */
           const newSource = trackingMarker + source;
+
           compilation.assets[assetName] = {
             source: () => newSource,
             size: () => newSource.length,

--- a/src/index.js
+++ b/src/index.js
@@ -208,11 +208,12 @@ class HawkWebpackPlugin {
    */
   addTrackingMarker(compilation) {
     const trackingMarker = '/*! HAWK:tracked */\n';
-    // JavaScript file extensions to track
     const jsExtensions = ['js', 'mjs', 'cjs'];
 
     Object.keys(compilation.assets).forEach((assetName) => {
-      // Filter only JS files (chunks) - includes files compiled from TypeScript
+      /**
+       * Filter only JS files (chunks) - includes files compiled from TypeScript
+       */
       const filename = assetName.split('?')[0];
       const extension = filename.split('.').pop();
 

--- a/src/index.js
+++ b/src/index.js
@@ -74,6 +74,11 @@ class HawkWebpackPlugin {
    * @param {Compiler} compiler
    */
   apply(compiler) {
+    // Add tracking marker to JS chunks before emitting
+    compiler.hooks.emit.tap('HawkWebpackPlugin', (compilation) => {
+      this.addTrackingMarker(compilation);
+    });
+
     compiler.hooks.afterEmit.tapPromise('HawkWebpackPlugin',
       /**
        * @param {Compilation} compilation
@@ -191,6 +196,39 @@ class HawkWebpackPlugin {
    */
   getReleaseId(compilation) {
     return compilation.hash;
+  }
+
+  /**
+   * Add tracking marker to JavaScript chunk files
+   *
+   * @param {Compilation} compilation
+   * @returns {void}
+   */
+  addTrackingMarker(compilation) {
+    const trackingMarker = '/*! HAWK:tracked */\n';
+    // JavaScript file extensions to track
+    const jsExtensions = ['js', 'mjs', 'cjs'];
+
+    Object.keys(compilation.assets).forEach((assetName) => {
+      // Filter only JS files (chunks) - includes files compiled from TypeScript
+      const filename = assetName.split('?')[0];
+      const extension = filename.split('.').pop();
+
+      if (jsExtensions.includes(extension) && !filename.endsWith('.map')) {
+        const asset = compilation.assets[assetName];
+        const source = asset.source();
+
+        // Check if marker already exists to avoid duplicates
+        if (!source.includes('HAWK:tracked')) {
+          // Prepend marker to the beginning of the file
+          const newSource = trackingMarker + source;
+          compilation.assets[assetName] = {
+            source: () => newSource,
+            size: () => newSource.length,
+          };
+        }
+      }
+    });
   }
 
   /**


### PR DESCRIPTION
This PR adds a tracking marker (`/*! HAWK:tracked */`) to all JavaScript chunk files generated by Webpack. The marker is injected at the beginning of each JS file during the emit phase, after minification but before files are written to disk.
<img width="656" height="517" alt="Снимок экрана 2025-11-22 в 16 54 37" src="https://github.com/user-attachments/assets/66eeabb2-9e46-4b35-9aa2-8e2168e1d533" />
