### PR TITLE
fix(fetch): multipart data streaming

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hawk.so/webpack-plugin",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Webpack plugin for sending source-maps to the Hawk",
   "main": "src/index.js",
   "repository": "https://github.com/codex-team/hawk.webpack.plugin.git",

--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,7 @@ class HawkWebpackPlugin {
   }) {
     this.releaseId = release;
     this.releaseInfoFile = releaseInfoFile;
-    this.requestTimeout = 50;
+    this.requestTimeout = 5000;
     this.removeSourceMaps = removeSourceMaps;
 
     this.integrationToken = integrationToken;
@@ -344,19 +344,26 @@ class HawkWebpackPlugin {
           Authorization: `Bearer ${this.integrationToken}`,
           ...data.getHeaders(),
         },
-      }, (response) => {
+      });
+
+      request.on('response', (response) => {
+        let body = '';
         response.setEncoding('utf8');
-        response.on('data', (chunk) => {
-          resolve(chunk);
-        });
+        response.on('data', chunk => body += chunk);
+        response.on('end', () => resolve(body));
       });
 
-      request.on('error', (e) => {
-        reject(e);
-      });
+      request.on('error', reject);
 
-      request.write(data.getBuffer());
-      request.end();
+      data.getLength((err, length) => {
+        if (err) {
+          request.destroy(err);
+          return;
+        }
+
+        request.setHeader('Content-Length', length);
+        data.pipe(request);
+      });
     });
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -370,6 +370,7 @@ class HawkWebpackPlugin {
       data.getLength((err, length) => {
         if (err) {
           request.destroy(err);
+          reject(err);
           return;
         }
 

--- a/src/index.js
+++ b/src/index.js
@@ -350,7 +350,19 @@ class HawkWebpackPlugin {
         let body = '';
         response.setEncoding('utf8');
         response.on('data', chunk => body += chunk);
-        response.on('end', () => resolve(body));
+        response.on('end', () => {
+          const statusCode = response.statusCode;
+
+          if (typeof statusCode === 'number' && statusCode >= 200 && statusCode < 300) {
+            resolve(body);
+          } else {
+            const error = new Error('Request failed with status code ' + statusCode);
+
+            error.statusCode = statusCode;
+            error.body = body;
+            reject(error);
+          }
+        });
       });
 
       request.on('error', reject);


### PR DESCRIPTION
#### Problem

For large files sometimes we were facing unexpected fetch behaviour

#### Causes
- `content-length` header is never set (so it works only for `multipart/form-data` chunks up to ~2 mb)
- request timeout is 50ms, seems violent for large file transfers, also we resolve the fetch promise only on first response chunk
```
response.on('data', (chunk) => {
  resolve(chunk);
});
```
if our request is large — error might appear on the other response chunks.

Here is collector error example:
![telegram-cloud-photo-size-2-5348154064111341811-y](https://github.com/user-attachments/assets/6c8322f1-5841-452e-b5c0-c026949ab3c7)

it leads to plugin error only if i check for other chunks with larger timeout

#### Solutions
- use data.pipe() — stream instead of full buffer sending (with data.getBuffer())
- increase timeout — 5000ms
- handle all of the response chunks till the end
